### PR TITLE
Compatibility updates for perccli 007.0529.0000.0000 and PERC H330

### DIFF
--- a/check_perccli
+++ b/check_perccli
@@ -85,7 +85,8 @@ def main():
     else:
         log.debug('SSH connection established')
 
-    stdin, stdout, stderr = ssh_client.exec_command('%s /call show all j' % args.perccli_path)
+    # we cd to the dir with the executable because newer versions of perccli depend on libstorelib.so which is in the same directory as perccli executable
+	stdin, stdout, stderr = ssh_client.exec_command('cd `dirname %s`; %s /call show all j' % (args.perccli_path, args.perccli_path))
 
     stdout = stdout.read().strip().decode('utf-8')
     try:
@@ -116,7 +117,7 @@ def main():
             pd_state = pd.get('State')
             if pd_state == 'Rbld' and exit_code < 1:
                 exit_code = 1
-            elif pd_state not in ['Onln', 'UGood']:
+            elif pd_state not in ['Onln', 'UGood', 'JBOD']:
                 exit_code = 2
             log.debug('C%s PD%s: %s %s (%s)' % (c, p, pd.get('Model'), pd.get('Size'), pd_state))
             msg.append('PD%s: %s' % (p, pd_state))
@@ -134,11 +135,15 @@ def main():
             log.debug('C%s VD%s: %s (%s)' % (c, v, vd.get('TYPE'), vd_state))
             msg.append('VD%s: %s%s' % (v, vd_state, ' (Inconsistent)' if vd_consist == 'No' else ''))
 
-        battery_state = controller.get('Response Data').get('BBU_Info')[0].get('State')
-        if battery_state != 'Optimal':
-            exit_code = 2
-        log.debug('C%s BBU (%s)' % (c, battery_state))
-        msg.append('BBU: %s' % battery_state)
+        bbu = controller.get('Response Data').get('BBU_Info')
+
+        # Some RAID cards like H330 do not have a battery so make this optional
+        if (bbu != None):
+          battery_state = bbu[0].get('State')
+          if battery_state != 'Optimal':
+              exit_code = 2
+          log.debug('C%s BBU (%s)' % (c, battery_state))
+          msg.append('BBU: %s' % battery_state)
 
         die(exit_code, ', '.join(msg) if msg else 'No problems detected')
 


### PR DESCRIPTION
Added some fixes for compatibility with PERC H330 and new perccli.
This version of perccli depends on a library called libstorelib.so that is under /opt/lsi/perccli so changed it to cd to that directory or it cannot find the library.
If you connect a disk directly to PERC card then status shows as JBOD so added that to 'good' status list.
The H330 does not have a battery so made that part of the check optional.

Tested with ESXi 6.7u2 with a PERC H330 with perccli 007.0529.0000.0000